### PR TITLE
Fix FAQ layout on mobile screens

### DIFF
--- a/src/assets/home/faq/faq_wave.svg
+++ b/src/assets/home/faq/faq_wave.svg
@@ -1,4 +1,4 @@
-<svg width="539" height="1086" viewBox="0 0 539 1086" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="1441" height="1086" viewBox="0 0 1441 1086" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <rect width="1441" height="1086" fill="url(#pattern0)"/>
 <defs>
 <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">

--- a/src/pages/Home/FAQ/styles.module.scss
+++ b/src/pages/Home/FAQ/styles.module.scss
@@ -1,29 +1,32 @@
 .faq {
   position: relative;
   padding-top: 1px;
+  overflow: hidden;
+  width: 100%;
 
   display: flex;
   flex-direction: column;
   color: white;
 
   .wave {
-    position: relative;
-    margin-top: 5%;
-    margin-right: 0%;
-    margin-bottom: 1px;
-    max-height: 960px;
+    position: absolute;
+    left: 63%;
+    height: 100%;
+    @media screen and (min-width: 1800px) {
+      left: unset;
+      right: -250px;
+    }
   }
 
   .content {
-    position: absolute;
     z-index: 1;
     margin-left: 10%;
-    margin-right: 45%;
-    max-width: 900px;
+    width: 50%;
     padding-bottom: 1px;
+    margin-bottom: 50px;
 
-    @media screen and (min-width: 1600px) {
-      width: 1100px;
+    @media screen and (min-width: 1800px) {
+      width: 1000px;
       font-size: 1.05em;
     }
   


### PR DESCRIPTION
- Replaces FAQ wave asset with one that includes the entire wave (instead of just the visible portion on Figma)
- Update CSS to ensure wave scales appropriately and FAQ section doesn't overlap with following section
  - The updated wave doesn't preserve the exact same widths as before, but should be able to be easily updated to do so if necessary

| Before at 400px width | After at 400px width|
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/22779056/130529345-96ede795-ab81-45f7-9fc2-10fb989096bc.png) | ![image](https://user-images.githubusercontent.com/22779056/130531390-49ee8b36-c7a4-43ca-a2df-d556d1844bf8.png) |