### PR TITLE
Fix double scrollbar for event info section

### DIFF
--- a/src/pages/Home/EventInfo/styles.module.scss
+++ b/src/pages/Home/EventInfo/styles.module.scss
@@ -1,6 +1,7 @@
 .eventInfo {
   position: relative;
   padding-top: 1px;
+  min-height: calc(960px + 10vw);
 
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Currently the event info section displays an extra scrollbar on certain screen sizes. This happens because the height of the event info section is based on the height of the content text, and sometimes the content's height is smaller than the wave's height, resulting in an extra scrollbar.

This PR forces the height of the event info section to be at least `960px + 10vw` to ensure it's always at least the wave's height.
- `960px` is the height of the wave
- `10vw` is the wave's margin top
- set `min-height` instead of just `height` so that if the text content is longer than the wave, the event info section still enlarges to encompass the text

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/22779056/130689513-3928c87d-2c93-42f3-80ac-acc5e0230c8b.png) | ![image](https://user-images.githubusercontent.com/22779056/130689545-60d5160b-809f-487d-b639-4e59632ca71d.png) |

